### PR TITLE
Bump to version 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pufr
 Type: Package
 Title: Tools For Analysis Of Physical Unclonable Functions (PUFs)
-Version: 0.5.0
+Version: 0.5.1
 Author: Sergio Vinagrero
 Maintainer: Sergio Vinagrero <servinagrero@gmail.com>
 Description: Functions and algorithms for the analysis and evaluation of Physical Unclonable Functions (PUFs).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# pufr 0.5.1
+
+* General fixes
+* Improved the test suite. This test suite will be used to check the proper behaviour of all the functions and will be used as the reference for the Python version.
+* Store names of the crps (devices, challenges and samples) when computing metrics
+
 # pufr 0.5.0
 
 * Make `rbits` create vector, matrix and array, for convenience purposes.

--- a/R/formulas.R
+++ b/R/formulas.R
@@ -55,7 +55,7 @@ entropy_bits <- function(v) {
 
 #' Shannon entropy for probabilities
 #'
-#' @param v A vector of probabilities where each probability is treated as P(1)
+#' @param v A vector of probabilities where each value is treated as the probability of success or P(1)
 #'
 #' @returns The Shannon entropy of each probability
 #'
@@ -74,7 +74,7 @@ entropy_p <- function(v) {
 #' @details
 #' Uniformity measures the distribution of 1s and 0s across all CRPs for each device. To calculate uniformity, `margin` should be 1.
 #'
-#' \deqn{Uniformity = \frac{1}{\#C} \sum_{c = 0}^{\#C} crp_c}
+#' \deqn{Uniformity(d) = \frac{1}{\#C} \sum_{r \in R_d} r}
 #'
 #' @param crps A bit vector or a 2D CRP matrix
 #'
@@ -106,7 +106,7 @@ uniformity <- function(crps) {
 #' @details
 #' Bitaliasing measures the distribution of 1s and 0s for a single CRPs across all devices.
 #'
-#' \deqn{Bitaliasing = \frac{1}{\#D} \sum_{d = 0}^{\#D} crp_d}
+#' \deqn{Bitaliasing(c) = \frac{1}{\#D} \sum_{d \in D} r_c}
 #'
 #' @param crps A bit vector or a 2D CRP matrix
 #'
@@ -129,13 +129,13 @@ bitaliasing <- function(crps) {
 #'
 #' A response is reliable if it does not change in time, thus, its intra Hamming distance is equal to 0.
 #'
-#' If `crps` is a 2D matrix, it is assumed that each row corresponds to a sample and each column to a CRP. The `ref_sample` will say which row is the sample taken as reference. In the case of a 3D matrix, each row corresponds to a device, each column to a CRP and each 3rd dimension to a different sample.
+#' If `crps` is a 2D matrix, it is assumed that each row corresponds to a sample and each column to a CRP. The `ref_sample` will dictate which row is the sample taken as reference. In the case of a 3D matrix, each row corresponds to a device, each column to a CRP and the 3rd dimension represents the different samples.
 #'
 #' @details
 #' The order of the samples is calculated as \code{setdiff(seq_len(nsamples), ref_sample)} where `nsamples` corresponds to \code{nrow(crps)} in the case of a 2D matrix and \code{dim(crps)[3]} in the case of a 3D matrix.
 #'
 #' @param crps A binary vector, 2D matrix or 3D array.
-#' @param ref Numeric index for the reference sample: If `crps` is a vector, is the index of the reference sample; If `crps` is a 2D matrix, the row to use as reference; If `crps` is a 3D array,the row for all 3rd dimension matrix.
+#' @param ref Numeric index for the reference sample: If `crps` is a vector, is the index of the reference sample; If `crps` is a 2D matrix, the row to use as reference; If `crps` is a 3D array, the row for all 3rd dimension matrix.
 #'
 #' @returns If `crps` is a vector, the intra Hamming distance of the vector. If `crps` is a 2D matrix, the reliability of each column as a vector of size \code{ncol(crps) - 1}. If `crps` is a 3D array, a 2D matrix where each row contains the intra Hamming distance all samples.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -149,23 +149,26 @@ ratio_bits <- function(v) {
 #' @param fn Function that receives two rows.
 #' @param ... Rest of arguments passed to `fn`.
 #'
-#' @returns Vector containing the results of all comparisons.
+#' @returns List containing the results of applying the function to each pair of rows.
 #' @export
 #' @examples
 #' #' Compare a matrix by pairs of rows
 #' m <- rbits(c(5, 5))
 #' res <- compare_pairwise(m, hamming_dist, norm = TRUE)
-#' res
+#' unlist(res)
 #' length(res) == (5 * 4 / 2)
 #'
 #' ## Equivalence to uniqueness
 #' res <- compare_pairwise(m, function(f, s) 1 - hamming_dist(f, s, norm = TRUE))
-#' all(uniqueness(m) == res)
+#' all(uniqueness(m) == unlist(res))
 compare_pairwise <- function(m, fn, ...) {
-  rows <- nrow(m)
+  pairs <- lapply(seq_len(nrow(m) - 1), function(i) {
+    len <- length(seq(i+1, nrow(m)))
+    mapply(c, rep(i, len), seq(i + 1, nrow(m)), SIMPLIFY=FALSE)
+  })
+  pairs <- unlist(pairs, recursive = FALSE)
 
-  pairs <- do.call(rbind, sapply(seq(1, rows - 1), function(i) {
-    cbind(rep(i, rows - i), seq(i + 1, rows))
-  }))
-  apply(t(pairs), 2, function(p) fn(m[p[1], ], m[p[2], ], ...))
+  lapply(pairs, function(p) fn(m[p[1], ], m[p[2], ], ...))
 }
+
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 #' Random bit vector, matrix or array
 #'
-#' This function is a wrapper around [sample] to generate bit vectors. The matrix and array version are creating by row.
+#' This function is a wrapper around [rbinom] to generate bit vectors. The matrix and array version are creating by row.
 #'
 #' @param size The size of the vector. Can be a list of dimensions to create a vector, matrix or array. If a vector larger than 3 is provided, each value is treated as the probability of obtaining 1 and a vector of bits is generated using a binomial distribution.
 #' @param p Probability of obtaining a 1. By default it's `0.5`.
@@ -46,7 +46,7 @@ rbits <- function(size, p = 0.5, ...) {
 #' The Hamming distance of two vectors corresponds to the number of positions where the values differ.
 #'
 #' @details
-#' NAs are discarded in any of the vectors.
+#' NAs are discarded in any of the vectors by using `na.rm = TRUE` in `sum`.
 #'
 #' @param x A numeric or logical vector
 #' @param y A numeric or logical vector
@@ -75,7 +75,7 @@ hamming_dist <- function(x, y, norm = FALSE) {
 #' For a binary vector, it corresponds to the number of 1s.
 #'
 #' @details
-#' NAs are discarded in the vector.
+#' NAs are discarded in the vector by using `na.rm = TRUE` in `sum`.
 #'
 #' @param v A logical or numeric vector
 #' @param norm If `TRUE` (default is `FALSE`) normalize the vector
@@ -142,11 +142,10 @@ ratio_bits <- function(v) {
 #' Compare a matrix by pairs of rows
 #'
 #' @description
-#' Each pair of rows is compared using the given function.
-#' The pairs are chosen without repetition.
+#' Each pair of rows is compared using the given function. The pairs are chosen without repetition.
 #'
 #' @param m Vector of values.
-#' @param fn Function that receives two rows.
+#' @param fn Function that receives two row vectors.
 #' @param ... Rest of arguments passed to `fn`.
 #'
 #' @returns List containing the results of applying the function to each pair of rows.

--- a/man/bitaliasing.Rd
+++ b/man/bitaliasing.Rd
@@ -20,7 +20,7 @@ Like \code{Unformity}, this function assumes that the CRPs are supplied in a 2D 
 
 Bitaliasing measures the distribution of 1s and 0s for a single CRPs across all devices.
 
-\deqn{Bitaliasing = \frac{1}{\#D} \sum_{d = 0}^{\#D} crp_d}
+\deqn{Bitaliasing(c) = \frac{1}{\#D} \sum_{d \in D} r_c}
 }
 \examples{
 ## Bitaliasing of a matrix

--- a/man/compare_pairwise.Rd
+++ b/man/compare_pairwise.Rd
@@ -9,7 +9,7 @@ compare_pairwise(m, fn, ...)
 \arguments{
 \item{m}{Vector of values.}
 
-\item{fn}{Function that receives two rows.}
+\item{fn}{Function that receives two row vectors.}
 
 \item{...}{Rest of arguments passed to \code{fn}.}
 }
@@ -17,8 +17,7 @@ compare_pairwise(m, fn, ...)
 List containing the results of applying the function to each pair of rows.
 }
 \description{
-Each pair of rows is compared using the given function.
-The pairs are chosen without repetition.
+Each pair of rows is compared using the given function. The pairs are chosen without repetition.
 }
 \examples{
 #' Compare a matrix by pairs of rows

--- a/man/compare_pairwise.Rd
+++ b/man/compare_pairwise.Rd
@@ -14,7 +14,7 @@ compare_pairwise(m, fn, ...)
 \item{...}{Rest of arguments passed to \code{fn}.}
 }
 \value{
-Vector containing the results of all comparisons.
+List containing the results of applying the function to each pair of rows.
 }
 \description{
 Each pair of rows is compared using the given function.
@@ -24,10 +24,10 @@ The pairs are chosen without repetition.
 #' Compare a matrix by pairs of rows
 m <- rbits(c(5, 5))
 res <- compare_pairwise(m, hamming_dist, norm = TRUE)
-res
+unlist(res)
 length(res) == (5 * 4 / 2)
 
 ## Equivalence to uniqueness
 res <- compare_pairwise(m, function(f, s) 1 - hamming_dist(f, s, norm = TRUE))
-all(uniqueness(m) == res)
+all(uniqueness(m) == unlist(res))
 }

--- a/man/entropy_p.Rd
+++ b/man/entropy_p.Rd
@@ -7,7 +7,7 @@
 entropy_p(v)
 }
 \arguments{
-\item{v}{A vector of probabilities where each probability is treated as P(1)}
+\item{v}{A vector of probabilities where each value is treated as the probability of success or P(1)}
 }
 \value{
 The Shannon entropy of each probability

--- a/man/hamming_dist.Rd
+++ b/man/hamming_dist.Rd
@@ -26,7 +26,7 @@ The Hamming distance
 The Hamming distance of two vectors corresponds to the number of positions where the values differ.
 }
 \details{
-NAs are discarded in any of the vectors.
+NAs are discarded in any of the vectors by using \code{na.rm = TRUE} in \code{sum}.
 }
 \examples{
 hamming_dist(c(0, 1, 0), c(0, 0, 0))

--- a/man/hamming_weight.Rd
+++ b/man/hamming_weight.Rd
@@ -19,7 +19,7 @@ The Hamming weight is the number of non null symbols in a vector.
 For a binary vector, it corresponds to the number of 1s.
 }
 \details{
-NAs are discarded in the vector.
+NAs are discarded in the vector by using \code{na.rm = TRUE} in \code{sum}.
 }
 \examples{
 ## Weight of the vector

--- a/man/intra_hd.Rd
+++ b/man/intra_hd.Rd
@@ -9,7 +9,7 @@ intra_hd(crps, ref = 1)
 \arguments{
 \item{crps}{A binary vector, 2D matrix or 3D array.}
 
-\item{ref}{Numeric index for the reference sample: If \code{crps} is a vector, is the index of the reference sample; If \code{crps} is a 2D matrix, the row to use as reference; If \code{crps} is a 3D array,the row for all 3rd dimension matrix.}
+\item{ref}{Numeric index for the reference sample: If \code{crps} is a vector, is the index of the reference sample; If \code{crps} is a 2D matrix, the row to use as reference; If \code{crps} is a 3D array, the row for all 3rd dimension matrix.}
 }
 \value{
 If \code{crps} is a vector, the intra Hamming distance of the vector. If \code{crps} is a 2D matrix, the reliability of each column as a vector of size \code{ncol(crps) - 1}. If \code{crps} is a 3D array, a 2D matrix where each row contains the intra Hamming distance all samples.
@@ -21,7 +21,7 @@ The intra Hamming distance of two sets of CRPs measures the numbers of CRPs that
 
 A response is reliable if it does not change in time, thus, its intra Hamming distance is equal to 0.
 
-If \code{crps} is a 2D matrix, it is assumed that each row corresponds to a sample and each column to a CRP. The \code{ref_sample} will say which row is the sample taken as reference. In the case of a 3D matrix, each row corresponds to a device, each column to a CRP and each 3rd dimension to a different sample.
+If \code{crps} is a 2D matrix, it is assumed that each row corresponds to a sample and each column to a CRP. The \code{ref_sample} will dictate which row is the sample taken as reference. In the case of a 3D matrix, each row corresponds to a device, each column to a CRP and the 3rd dimension represents the different samples.
 }
 \details{
 The order of the samples is calculated as \code{setdiff(seq_len(nsamples), ref_sample)} where \code{nsamples} corresponds to \code{nrow(crps)} in the case of a 2D matrix and \code{dim(crps)[3]} in the case of a 3D matrix.

--- a/man/rbits.Rd
+++ b/man/rbits.Rd
@@ -17,7 +17,7 @@ rbits(size, p = 0.5, ...)
 The generated bit vector
 }
 \description{
-This function is a wrapper around \link{sample} to generate bit vectors. The matrix and array version are creating by row.
+This function is a wrapper around \link{rbinom} to generate bit vectors. The matrix and array version are creating by row.
 }
 \examples{
 ## Unbiased probabilities

--- a/man/reliability.Rd
+++ b/man/reliability.Rd
@@ -9,7 +9,7 @@ reliability(crps, ref = 1)
 \arguments{
 \item{crps}{A binary vector, 2D matrix or 3D array.}
 
-\item{ref}{Numeric index for the reference sample: If \code{crps} is a vector, is the index of the reference sample; If \code{crps} is a 2D matrix, the row to use as reference; If \code{crps} is a 3D array,the row for all 3rd dimension matrix.}
+\item{ref}{Numeric index for the reference sample: If \code{crps} is a vector, is the index of the reference sample; If \code{crps} is a 2D matrix, the row to use as reference; If \code{crps} is a 3D array, the row for all 3rd dimension matrix.}
 }
 \description{
 The reliability of a PUF is defined as \eqn{1 - Intra_{HD}}

--- a/man/uniformity.Rd
+++ b/man/uniformity.Rd
@@ -18,7 +18,7 @@ This function assumes that if the CRPs are supplied in a 2D matrix, each row cor
 \details{
 Uniformity measures the distribution of 1s and 0s across all CRPs for each device. To calculate uniformity, \code{margin} should be 1.
 
-\deqn{Uniformity = \frac{1}{\#C} \sum_{c = 0}^{\#C} crp_c}
+\deqn{Uniformity(d) = \frac{1}{\#C} \sum_{r \in R_d} r}
 }
 \examples{
 ## Uniformity of a vector

--- a/tests/testthat/test-formulas.R
+++ b/tests/testthat/test-formulas.R
@@ -1,0 +1,91 @@
+test_that("entropy of vector full of 0s", {
+  v <- rbits(1000, p = 0)
+  entropy <- entropy_bits(v)
+  expect_equal(entropy, 0)
+})
+
+test_that("entropy of vector full of 1s", {
+  v <- rbits(1000, p = 1)
+  entropy <- entropy_bits(v)
+  expect_equal(entropy, 0)
+})
+
+test_that("entropy of a unbiased binary vector", {
+  v <- rbits(1000)
+  entropy <- entropy_bits(v)
+  expect_lt(1 - entropy, 0.05)
+})
+
+test_that("uniformity of a non biased vector is 0.5", {
+  v <- rbits(1000)
+  unif_h <- entropy_p(uniformity(v))
+  expect_gt(unif_h, 0.9)
+})
+
+test_that("uniformity only works on vectors and matrices", {
+  v <- rbits(100)
+  expect_no_error(uniformity(v))
+  m <- rbits(c(5, 10))
+  expect_no_error(uniformity(m))
+  arr <- rbits(c(5, 10, 3))
+  expect_error(uniformity(arr))
+})
+
+test_that("bitaliasing of a non biased vector is 0.5", {
+  v <- rbits(1000)
+  unif_h <- entropy_p(uniformity(v))
+  expect_gt(unif_h, 0.9)
+})
+
+test_that("bitaliasing only works on matrices", {
+  v <- rbits(10)
+  expect_error(bitaliasing(v))
+  m <- rbits(c(5, 10))
+  expect_no_error(bitaliasing(m))
+  arr <- rbits(c(5, 10, 3))
+  expect_error(bitaliasing(arr))
+})
+
+test_that("intra_hd works on vectors", {
+  v <- rbits(10)
+  ihd <- intra_hd(v, 1)
+  expect_true(is.vector(ihd))
+  expect_equal(length(ihd), length(v) - 1)
+})
+
+test_that("intra_hd works on matrices", {
+  m <- rbits(c(5, 10))
+  ihd <- intra_hd(m, 1)
+  expect_true(is.matrix(ihd))
+  expect_equal(dim(ihd), c(4, 10))
+})
+
+test_that("intra_hd works on arrays", {
+  arr <- rbits(c(3, 10, 5))
+  ihd <- intra_hd(arr, 1)
+  expect_true(is.matrix(ihd))
+  expect_equal(dim(ihd), c(3, 10))
+})
+
+test_that("intra_hd fails when providing a wrong reference", {
+  v <- rbits(10)
+  expect_error(intra_hd(v, 12))
+  m <- rbits(c(5, 10))
+  expect_error(intra_hd(m, -2))
+  arr <- rbits(c(5, 10, 3))
+  expect_error(intra_hd(arr, 20))
+})
+
+test_that("uniqueness provides all results", {
+  m <- rbits(c(5, 10))
+  size <- (nrow(m) * (nrow(m) - 1)) / 2
+  uniq <- uniqueness(m)
+  expect_equal(length(uniq), size)
+  expect_lt((mean(uniq) - 0.5), 0.1)
+})
+
+test_that("compare_pairwise behaves like uniqueness", {
+  m <- rbits(c(5, 10))
+  fn <- function(x, y) 1 - hamming_dist(x, y, TRUE)
+  expect_true(all(uniqueness(m) == compare_pairwise(m, fn)))
+})

--- a/tests/testthat/test-metrics.R
+++ b/tests/testthat/test-metrics.R
@@ -1,83 +1,26 @@
-test_that("rbits creates a vector, matrix and array", {
-  v <- rbits(10)
-  expect_equal(length(v), 10)
+test_that("metrics has the correct dimensions", {
   m <- rbits(c(5, 10))
-  expect_equal(dim(m), c(5, 10))
-  a <- rbits(c(5, 10, 3))
-  expect_equal(dim(a), c(5, 10, 3))
+  expect_equal(dim(metrics(m)), c(5, 10, 1))
+  arr <- rbits(c(5, 10, 3))
+  expect_equal(dim(metrics(arr)), c(5, 10, 3))
 })
 
-test_that("entropy of vector full of 0s", {
-  v <- rbits(1000, p = 0)
-  entropy <- entropy_bits(v)
-  expect_equal(entropy, 0)
+
+test_that("reliability is NA when a matrix is supplied", {
+  arr <- rbits(c(5, 10, 3))
+  met <- metrics(arr[,,1])
+  expect_true(is.na(met$reliability))
+  met <- metrics(arr)
+  expect_true(is.matrix(met$reliability))
 })
 
-test_that("entropy of vector full of 1s", {
-  v <- rbits(1000, p = 1)
-  entropy <- entropy_bits(v)
-  expect_equal(entropy, 0)
-})
+test_that("with_entropy modifies uniformity and bitaliasing", {
+  m <- rbits(c(5, 10), p = 1)
+  met <- metrics(m)
+  expect_true(all(met$uniformity == 1))
+  expect_true(all(met$bitaliasing == 1))
 
-test_that("entropy of a unbiased binary vector", {
-  v <- rbits(1000)
-  entropy <- entropy_bits(v)
-  expect_lt(1 - entropy, 0.05)
-})
-
-test_that("hamming_weight handles `NA`", {
-  v <- sample(c(0, 1, NA), 1000, replace = TRUE)
-  unif <- hamming_weight(v, norm = TRUE)
-  expect_lt(abs(unif - 0.5), 0.1)
-})
-
-test_that("uniformity of a bit vector", {
-  v <- rbits(1000)
-  unif <- uniformity(v)
-  expect_lt(abs(unif - 0.5), 0.1)
-})
-
-test_that("uniformity of a crp table", {
-  mat <- rbits(c(10, 500))
-  bitalias <- mean(uniformity(mat))
-  expect_lt(abs(bitalias - 0.5), 0.1)
-})
-
-test_that("bitaliasing of a crp table", {
-  mat <- mat <- rbits(c(10, 500))
-  bitalias <- mean(bitaliasing(mat))
-  expect_lt(abs(bitalias - 0.5), 0.1)
-})
-
-test_that("intra_hd works on a 2D matrix", {
-  mat <- mat <- rbits(c(5, 10), p = rep(0, 50))
-  hd <- intra_hd(mat, ref = 1)
-  expect_length(hd, (nrow(mat) - 1) * ncol(mat))
-  expect_equal(mean(hd), 1)
-})
-
-test_that("intra_hd works on a 3D matrix", {
-  arr <- array(0, dim = c(5, 10, 7))
-  hds <- intra_hd(arr)
-  expect_equal(length(dim(hds)), 2)
-  expect_equal(dim(hds)[1], nrow(arr))
-  expect_equal(dim(hds)[2], ncol(arr))
-  expect_equal(mean(hds), 1)
-})
-
-test_that("intra_hd throw an error with an invalid ref_sample", {
-  mat <- matrix(0, nrow = 5, ncol = 10)
-  expect_error(intra_hd(mat, ref = 10))
-})
-
-test_that("intra_hd throw an error with an invalid input", {
-  expect_error(intra_hd(list(a = 1, b = 2)))
-})
-
-test_that("uniqueness works", {
-  mat <- rbits(c(5, 100))
-  hd <- uniqueness(mat)
-  npairs <- (nrow(mat) * (nrow(mat) - 1)) / 2
-  expect_length(hd, npairs)
-  expect_lt((mean(hd) - 0.5), 0.1)
+  met_ent <- with_entropy(met)
+  expect_true(all(met_ent$uniformity == 0))
+  expect_true(all(met_ent$bitaliasing == 0))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,3 +1,18 @@
+test_that("rbits generates the correct size", {
+  v <- rbits(10)
+  m <- rbits(c(5, 10))
+  arr <- rbits(c(5, 10, 3))
+
+  expect_equal(length(v), 10)
+  expect_equal(dim(m), c(5, 10))
+  expect_equal(dim(arr), c(5, 10, 3))
+})
+
+test_that("rbits fails if number of probs does not match size", {
+  P <- runif(10)
+  expect_error(rbits(15, P))
+})
+
 test_that("hamming_weight handles `NA`", {
   v <- sample(c(0, 1, NA), 1000, replace = TRUE)
   weight <- hamming_weight(v, norm = TRUE)
@@ -8,12 +23,15 @@ test_that("hamming_dist fails on different lengths", {
   expect_error(hamming_dist(c(0, 0), c(0, 1, 0)))
 })
 
-test_that("ratio_bits handles `NA`", {
-  v <- sample(c(0, 1, NA), 1000, replace = TRUE)
-  expect_lt(abs(ratio_bits(v)), 0.1)
-})
-
 test_that("ratio_bits discards `NA`", {
   ratio <- ratio_bits(c(1, 0, 1, NA, NA))
   expect_equal(ratio, 1 / 3)
+})
+
+
+test_that('compare_pairwise creates all pairs of rows', {
+  m <- rbits(c(5, 10))
+  npairs <- (nrow(m) * (nrow(m) - 1)) / 2
+  res <- compare_pairwise(m, sum)
+  expect_equal(length(res), npairs)
 })


### PR DESCRIPTION
This minor version fixes a couple of bugs and allows caching the names of the CRPs when computing the metrics.

It also improves the test suited that will be used to ensure the behavior of the functions and used as reference for the Python version.